### PR TITLE
Nullcheck queues before accessing

### DIFF
--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -49,6 +49,9 @@ export default Service.extend({
   },
 
   scheduleWork(queueName, callback) {
+    if (!this.queues) {
+      return;
+    }
     const queue = this.queues[queueName];
     const token = new Token();
 
@@ -67,6 +70,9 @@ export default Service.extend({
   },
 
   flushQueue(queueName) {
+    if (!this.queues) {
+      return;
+    }
     const queue = this.queues[queueName];
     queue.isActive = false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-app-scheduler",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
I was running into an issue where the _willDestroy_ function was called but _scheduleWork_/_flushQueue_ were being called after. Since the queues were cleared, the code was throwing an error when trying to access the queues.

Tests are all passing.