### PR TITLE
Canceling run.later calls before starting new ones

### DIFF
--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -121,10 +121,13 @@ const Scheduler = Service.extend({
   },
 
   _rAFCallback(resolve) {
+    if (this._nextPaintTimeout) {
+      run.cancel(this._nextPaintTimeout);
+    }
+
     this._nextPaintTimeout = run.later(() => {
       this._nextAfterPaintPromise = null;
       this._nextPaintFrame = null;
-      this._nextPaintTimeout = null;
       resolve();
     }, 0);
   },

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -199,9 +199,9 @@ if (DEBUG) {
       const lastQueue = this.queues[lastQueueName];
 
       const hasActiveQueue = lastQueue && lastQueue.isActive;
-      const hasTasks = lastQueue.tasks.length > 0;
+      const hasTasks = lastQueue && lastQueue.tasks.length > 0;
 
-      return hasActiveQueue && hasTasks;
+      return hasActiveQueue || hasTasks;
     },
 
     /**

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -131,6 +131,7 @@ const Scheduler = Service.extend({
     this._nextPaintTimeout = run.later(() => {
       this._nextAfterPaintPromise = null;
       this._nextPaintFrame = null;
+      this._nextPaintTimeout = null;
       resolve();
     }, 0);
   },

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -122,7 +122,7 @@ const Scheduler = Service.extend({
   },
 
   _rAFCallback(resolve) {
-    if (this.isDestroying) {
+    if (this.isDestroying || this.isDestroyed) {
       return;
     }
 
@@ -180,7 +180,8 @@ if (DEBUG) {
       this._super(...arguments);
 
       if (Ember.testing) {
-        this._waiter = () => !(this.hasActiveQueue() || this.hasPendingTimers());
+        const shouldWaitOnTimers = this.hasActiveQueue() || this.hasPendingTimers();
+        this._waiter = () => shouldWaitOnTimers;
         Ember.Test.registerWaiter(this._waiter);
       }
     },

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -37,10 +37,6 @@ class Queue {
 const Scheduler = Service.extend({
   queueNames: ['afterFirstRoutePaint', 'afterContentPaint'],
 
-  router: Ember.computed(function() {
-    return Ember.getOwner(this).lookup('router:main');
-  }),
-
   init() {
     this._super();
     this._nextPaintFrame = null;
@@ -183,7 +179,7 @@ if (DEBUG) {
       this._super(...arguments);
 
       if (Ember.testing) {
-        this._waiter = () => !(this.hasActiveQueue() || this._nextPaintFrame || this._nextPaintTimeout);
+        this._waiter = () => !(this.hasActiveQueue() || this.hasPendingTimers());
         Ember.Test.registerWaiter(this._waiter);
       }
     },
@@ -204,6 +200,14 @@ if (DEBUG) {
       const hasTasks = lastQueue.tasks.length > 0;
 
       return hasActiveQueue && hasTasks;
+    },
+
+    /**
+     * Method to detect if there are still active timers
+     * @return {Boolean}
+     */
+    hasPendingTimers() {
+      return this._nextPaintFrame || this._nextPaintTimeout;
     },
 
     willDestroy() {


### PR DESCRIPTION
Each time that the service requests the next animation frame, a new `run.later` call is made. Through my debugging, I see this happening four times:

1) router `didTransition`
2) During the flushing of the `afterFirstRoutePaint` queue
3) During the flushing of the`afterContentPaint` queue
4) After the ‘afterContentPaint’ queue has been flushed

So, we now have multiple timers that have been setup, but we only have a handle to the last one. That means that only the last one will ever get canceled in willDestroy.