### PR TITLE
Check for destroying/destroyed when flushingQueue or RAF

### DIFF
--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -81,6 +81,10 @@ const Scheduler = Service.extend({
   },
 
   flushQueue(queueName) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
     const queue = this.queues[queueName];
     queue.isActive = false;
 
@@ -135,6 +139,10 @@ const Scheduler = Service.extend({
   },
 
   _rAFCallback(resolve) {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
     this._nextPaintTimeout = run.later(() => {
       this._nextAfterPaintPromise = null;
       this._nextPaintFrame = null;


### PR DESCRIPTION
This addresses #17 to check for destroying before running callbacks.

There was a slightly different implementation in #15 that was closed, but didn't seem to catch every potential callback.

No tests exist for this service since PR #26 and when the service was reintroduced in #28, no regression tests were added back for the previous service implementation.