### PR TITLE
Determining transition event names based on version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Using npm:
 npm install ember-app-scheduler --save
 ```
 
-The `ember-app-scheduler` addon connects its functionality via the application's router. By connecting to the router's `willTransition` and `didTransition` hooks, it ensures that the timing of its API is in sync with the application's timings.
+The `ember-app-scheduler` addon connects its functionality via the application's router. By connecting to the router's `routeWillChange`/`routeDidChange` hooks (`willTransition`/`didTransition` in Ember < 3.6), it ensures that the timing of its API is in sync with the application's timings.
 
 To connect to your router, import `setupRouter` and `reset` from `ember-app-scheduler` and invoke them:
 
@@ -96,7 +96,7 @@ export default Route.extend({
     whenRouteIdle().then(() => {
       // do non-critical work
     });
-  }
+  },
 });
 ```
 
@@ -116,7 +116,7 @@ export default Route.extend({
       // do work that needs to occur between the route being painted
       // and `whenRouteIdle`
     });
-  }
+  },
 });
 ```
 
@@ -146,7 +146,7 @@ export default Component.extend({
     whenRouteIdle().then(() => {
       this.set('showHiddenContent', true);
     });
-  }
+  },
 });
 ```
 
@@ -164,7 +164,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | component-with-deferred-stuff', function(hooks) {
+module('Integration | Component | component-with-deferred-stuff', function(
+  hooks
+) {
   setupRenderingTest(hooks);
 
   test('hidden content is rendered when route idle', async function(assert) {
@@ -190,7 +192,6 @@ module('Integration | Component | component-with-deferred-stuff', function(hooks
 For more advanced use cases, you may want to test the intermediate states of your promises. While this case is less common, `ember-app-scheduler` does provide mechanisms that allow you to do this.
 
 To see an example of this, you can look at `ember-app-scheduler`'s [own tests](https://github.com/ember-app-scheduler/ember-app-scheduler/blob/af688825af2591ffa97d9c0fa1e1d78d8a30731d/tests/integration/deferred-render-in-component-test.js#L1) which employ this mechanism.
-
 
 ### Acceptance Tests
 
@@ -247,24 +248,27 @@ module('Acceptance | when rendered tests', function(hooks) {
 
     await visit('/my-route');
 
-    assert.ok(find('.only-when-route-idle'), 'only-when-route-idle element exists');
+    assert.ok(
+      find('.only-when-route-idle'),
+      'only-when-route-idle element exists'
+    );
   });
 });
 ```
 
 ## Running
 
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+- `ember serve`
+- Visit your app at [http://localhost:4200](http://localhost:4200).
 
 ## Running Tests
 
-* `yarn test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
+- `yarn test` (Runs `ember try:each` to test your addon against multiple Ember versions)
+- `ember test`
+- `ember test --server`
 
 ## Building
 
-* `ember build`
+- `ember build`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -20,14 +20,6 @@ interface Capabilities {
 const APP_SCHEDULER_LABEL: string = 'ember-app-scheduler';
 const APP_SCHEDULER_HAS_SETUP: string = '__APP_SCHEDULER_HAS_SETUP__';
 
-let BEGIN_TRANSITION = 'willTransition';
-let END_TRANSITION = 'didTransition';
-
-if (gte('3.6.0')) {
-  BEGIN_TRANSITION = 'routeWillChange';
-  END_TRANSITION = 'routeDidChange';
-}
-
 let _whenRouteDidChange: IDeferred;
 let _whenRoutePainted: Promise<any>;
 let _whenRoutePaintedScheduleFn: Function;
@@ -67,8 +59,14 @@ export function setupRouter(router: Router) {
   }
 
   (router as any)[APP_SCHEDULER_HAS_SETUP] = true;
-  router.on(BEGIN_TRANSITION, beginTransition);
-  router.on(END_TRANSITION, endTransition);
+
+  if (gte('3.6.0')) {
+    router.on('routeWillChange', beginTransition);
+    router.on('routeDidChange', endTransition);
+  } else {
+    router.on('willTransition', beginTransition);
+    router.on('didTransition', endTransition);
+  }
 }
 
 export function reset() {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,88 +1,89 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-8'
+          ember: 'components/ember#lts-2-8',
         },
         resolutions: {
-          'ember': 'lts-2-8'
-        }
+          ember: 'lts-2-8',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': '~2.12.2'
-        }
+          ember: '~2.12.2',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
+          ember: 'components/ember#release',
         },
         resolutions: {
-          'ember': 'release'
-        }
+          ember: 'release',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
+          ember: 'components/ember#beta',
         },
         resolutions: {
-          'ember': 'beta'
-        }
+          ember: 'beta',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-canary',
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
+          ember: 'components/ember#canary',
         },
         resolutions: {
-          'ember': 'canary'
-        }
+          ember: 'canary',
+        },
       },
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
+          'ember-source': null,
+        },
+      },
     },
     {
       name: 'ember-default',
       npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+        devDependencies: {},
+      },
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@types/ember": "^3.0.23",
     "@types/rsvp": "^4.0.2",
-    "ember-cli-babel": "^7.1.3"
+    "ember-cli-babel": "^7.1.3",
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {
     "@glimmer/env": "^0.1.7",
@@ -49,6 +50,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-typescript": "^1.4.3",
     "ember-cli-uglify": "^2.1.0",
+    "ember-cli-version-checker": "^2.1.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -8,8 +8,10 @@ type RequestIdleCallbackDeadline = {
 };
 
 declare function requestIdleCallback(
-      callback: ((deadline: RequestIdleCallbackDeadline) => void),
-      opts?: RequestIdleCallbackOptions,
-    ): RequestIdleCallbackHandle;
+  callback: ((deadline: RequestIdleCallbackDeadline) => void),
+  opts?: RequestIdleCallbackOptions
+): RequestIdleCallbackHandle;
 
 declare function cancelIdleCallback(handle: RequestIdleCallbackHandle): void;
+
+declare module 'ember-compatibility-helpers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,6 +1106,13 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0-beta.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0-beta.6.tgz#ecdf6e408d5c863ab21740d7ad7f43f027d2f912"
@@ -3133,9 +3140,10 @@ ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
+  integrity sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==
   dependencies:
     resolve "^1.3.3"
     semver "^5.3.0"
@@ -3233,6 +3241,15 @@ ember-cli@~3.6.0:
     walk-sync "^0.3.2"
     watch-detector "^0.1.0"
     yam "^0.0.24"
+
+ember-compatibility-helpers@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
+  integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
Updates router events to optionally use `routeWillChange/routeDidChange` when using Ember version 3.6 or greater.