### PR TITLE
Fix `will/didTransition` deprecations in Ember 3.6

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -1,5 +1,6 @@
 import { Promise } from 'rsvp';
 import { run } from '@ember/runloop';
+import { getOwner } from '@ember/application';
 import Router from '@ember/routing/router';
 import { DEBUG } from '@glimmer/env';
 import { registerWaiter } from '@ember/test';
@@ -58,8 +59,15 @@ export function setupRouter(router: Router) {
   }
 
   (router as any)[APP_SCHEDULER_HAS_SETUP] = true;
-  router.on('willTransition', beginTransition);
-  router.on('didTransition', endTransition);
+  let owner = getOwner(router);
+  let service = owner.lookup('service:router');
+  if (service) {
+    service.on('routeWillChange', beginTransition);
+    service.on('routeDidChange', endTransition);
+  } else {
+    router.on('willTransition', beginTransition);
+    router.on('didTransition', endTransition);
+  }
 }
 
 export function reset() {


### PR DESCRIPTION
Listening for `willTransition`/`didTransition` on the router is deprecated in Ember 3.6.
Now the correct way of achieving the same functionality is listening for the `routeWillChange`
or `routeDidChange` on the *router service*.