### PR TITLE
Fixing test waiter to use requestAnimationFrame when in test mode

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -129,6 +129,8 @@ export function _getScheduleFn(
 
 export function _setCapabilities(newCapabilities = CAPABILITIES): void {
   _capabilities = newCapabilities;
+  _whenRoutePaintedScheduleFn = _getScheduleFn();
+  _whenRouteIdleScheduleFn = _getScheduleFn(USE_REQUEST_IDLE_CALLBACK);
 }
 
 _whenRoutePaintedScheduleFn = _getScheduleFn();

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { Promise } from 'rsvp';
 import { run } from '@ember/runloop';
 import Router from '@ember/routing/router';
@@ -118,7 +119,9 @@ export function routeSettled(): Promise<any> {
 export function _getScheduleFn(
   useRequestIdleCallback = false
 ): (callback: any) => number {
-  if (useRequestIdleCallback && _capabilities.requestIdleCallbackEnabled) {
+  if (DEBUG && useRequestIdleCallback && _capabilities.requestIdleCallbackEnabled) {
+    return (callback) => Ember.testing ? requestAnimationFrame(callback) : requestIdleCallback(callback);
+  } else if (useRequestIdleCallback && _capabilities.requestIdleCallbackEnabled) {
     return requestIdleCallback;
   } else if (_capabilities.requestAnimationFrameEnabled) {
     return requestAnimationFrame;

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -18,10 +18,10 @@ const REQUEST_IDLE_CALLBACK = requestIdleCallback;
 
 module('Unit | Scheduler', function(hooks) {
   hooks.afterEach(function() {
-    _setCapabilities();
-    reset();
     window.requestAnimationFrame = REQUEST_ANIMATION_FRAME;
     window.requestIdleCallback = REQUEST_IDLE_CALLBACK;
+    _setCapabilities();
+    reset();
   });
 
   test('whenRouteIdle resolves when transition ended', async function(assert) {
@@ -48,10 +48,14 @@ module('Unit | Scheduler', function(hooks) {
       requestIdleCallbackEnabled: false,
     });
 
-    window.requestAnimationFrame = () =>
+    window.requestAnimationFrame = callback => {
       assert.ok(false, 'requestAnimationFrame was used');
-    window.requestIdleCallback = () =>
+      callback();
+    };
+    window.requestIdleCallback = callback => {
       assert.ok(false, 'requestIdleCallback was used');
+      callback();
+    };
 
     beginTransition();
 
@@ -74,10 +78,14 @@ module('Unit | Scheduler', function(hooks) {
       requestIdleCallbackEnabled: false,
     });
 
-    window.requestAnimationFrame = () =>
+    window.requestAnimationFrame = callback => {
       assert.ok(true, 'requestAnimationFrame was used');
-    window.requestIdleCallback = () =>
+      callback();
+    };
+    window.requestIdleCallback = callback => {
       assert.ok(false, 'requestIdleCallback was used');
+      callback();
+    };
 
     beginTransition();
 

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -14,12 +14,14 @@ import {
 } from 'ember-app-scheduler/scheduler';
 
 const REQUEST_ANIMATION_FRAME = requestAnimationFrame;
+const REQUEST_IDLE_CALLBACK = requestIdleCallback;
 
 module('Unit | Scheduler', function(hooks) {
   hooks.afterEach(function() {
-    reset();
     _setCapabilities();
+    reset();
     window.requestAnimationFrame = REQUEST_ANIMATION_FRAME;
+    window.requestIdleCallback = REQUEST_IDLE_CALLBACK;
   });
 
   test('whenRouteIdle resolves when transition ended', async function(assert) {
@@ -45,8 +47,12 @@ module('Unit | Scheduler', function(hooks) {
       requestAnimationFrameEnabled: false,
       requestIdleCallbackEnabled: false,
     });
+
     window.requestAnimationFrame = () =>
       assert.ok(false, 'requestAnimationFrame was used');
+    window.requestIdleCallback = () =>
+      assert.ok(false, 'requestIdleCallback was used');
+
     beginTransition();
 
     let routeIdle = whenRouteIdle();
@@ -67,8 +73,12 @@ module('Unit | Scheduler', function(hooks) {
       requestAnimationFrameEnabled: true,
       requestIdleCallbackEnabled: false,
     });
+
     window.requestAnimationFrame = () =>
       assert.ok(true, 'requestAnimationFrame was used');
+    window.requestIdleCallback = () =>
+      assert.ok(false, 'requestIdleCallback was used');
+
     beginTransition();
 
     let routeIdle = whenRouteIdle();


### PR DESCRIPTION
In certain cases the test waiter never completes in tests when we're using whenRouteIdle. The hypothesis is that during tests, the main thread is pinned and never gets into an idle state, thus resulting in the requestIdleCallback to never fire.

This PR changes the semantics, during test only, of what schedule function is used. In test we will always fall back to `requestAnimationFrame` rather than `requestIdleCallback`. 