### PR TITLE
fix(scheduling): Change scheduling to use performance.mark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ jobs:
   include:
     # runs linting and tests with current locked deps
 
-    - stage: "Tests"
-      name: "Tests"
+    - stage: 'Tests'
+      name: 'Tests'
       install:
         - yarn install --non-interactive
       script:
@@ -42,26 +42,15 @@ jobs:
         - yarn lint:js
         - yarn test
 
-    - name: "Floating Dependencies"
-      script:
-        - yarn test
-
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - stage: 'Additional Tests'
+      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
-
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
-
-install:
-  - yarn install --no-lockfile --non-interactive
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The [documentation website](https://ember-app-scheduler.github.io/ember-app-sche
 
 ## Compatibility
 
-- Ember.js v2.18 or above
+- Ember.js v3.4 or above
 - Ember CLI v2.13 or above
 
 ## Installation

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -7,4 +7,5 @@ export {
   didTransition,
   whenRoutePainted,
   whenRouteIdle,
+  emitMark,
 } from 'ember-app-scheduler/scheduler';

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -119,7 +119,7 @@ export function setupRouter(router: Router, options: SchedulerOptions): void {
   (router as any)[APP_SCHEDULER_HAS_SETUP] = true;
 
   if (CAPABILITIES.performanceObserverEnabled) {
-    schedulerOptions = assign(DEFAULT_OPTIONS, options);
+    schedulerOptions = assign({}, DEFAULT_OPTIONS, options);
 
     installObserver();
   }

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 import { Promise } from 'rsvp';
-import { run } from '@ember/runloop';
+import { run, schedule } from '@ember/runloop';
+import { assign } from '@ember/polyfills';
 import Router from '@ember/routing/router';
 import { DEBUG } from '@glimmer/env';
-import { registerWaiter } from '@ember/test';
 import { gte } from 'ember-compatibility-helpers';
+import { buildWaiter, Token } from 'ember-test-waiters';
 
 interface Deferred {
   isResolved: boolean;
@@ -13,31 +14,78 @@ interface Deferred {
   reject: Function;
 }
 
+interface SchedulerOptions {
+  markName: string;
+  emitMark: boolean;
+}
+
 interface Capabilities {
   requestAnimationFrameEnabled: boolean;
   requestIdleCallbackEnabled: boolean;
+  performanceObserverEnabled: boolean;
 }
 
 const APP_SCHEDULER_LABEL: string = 'ember-app-scheduler';
 const APP_SCHEDULER_HAS_SETUP: string = '__APP_SCHEDULER_HAS_SETUP__';
+let PERFORMANCE_OBSERVER_SETUP: boolean = false;
 
 let _whenRouteDidChange: Deferred;
 let _whenRoutePainted: Promise<any>;
 let _whenRoutePaintedScheduleFn: Function;
 let _whenRouteIdle: Promise<any>;
 let _whenRouteIdleScheduleFn: Function;
-let _activeScheduledTasks: number = 0;
 const CAPABILITIES: Capabilities = {
   requestAnimationFrameEnabled: typeof requestAnimationFrame === 'function',
   requestIdleCallbackEnabled: typeof requestIdleCallback === 'function',
+  performanceObserverEnabled: typeof PerformanceObserver === 'function',
 };
+const DEFAULT_OPTIONS: SchedulerOptions = {
+  markName: 'routeIdle',
+  emitMark: true,
+};
+
 let _capabilities = CAPABILITIES;
+let schedulerOptions: SchedulerOptions = DEFAULT_OPTIONS;
 
 export const USE_REQUEST_IDLE_CALLBACK: boolean = true;
 export const SIMPLE_CALLBACK = (callback: Function) => callback();
 const IS_FASTBOOT = typeof (<any>window).FastBoot !== 'undefined';
+const waiter = buildWaiter('ember-app-scheduler-waiter');
+let _emitMark: Function = emitMark;
 
 reset();
+
+function installObserver() {
+  if (PERFORMANCE_OBSERVER_SETUP) {
+    return;
+  }
+
+  let observer = new PerformanceObserver(list => {
+    let entries = list.getEntriesByName(schedulerOptions.markName);
+
+    if (entries.length > 0) {
+      _whenRouteDidChange.resolve();
+    }
+  });
+  observer.observe({ entryTypes: ['mark'] });
+
+  PERFORMANCE_OBSERVER_SETUP = true;
+}
+
+export function emitMark() {
+  let emitMarkToken: Token = <Token>waiter.beginAsync();
+
+  schedule('afterRender', null, () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        performance.mark(schedulerOptions.markName);
+        _whenRouteDidChange.promise.finally(() =>
+          waiter.endAsync(emitMarkToken)
+        );
+      });
+    });
+  });
+}
 
 export function beginTransition(): void {
   if (_whenRouteDidChange.isResolved) {
@@ -52,15 +100,29 @@ export function beginTransition(): void {
 }
 
 export function endTransition(): void {
-  _whenRouteDidChange.resolve();
+  if (CAPABILITIES.performanceObserverEnabled) {
+    if (!schedulerOptions.emitMark) {
+      return;
+    }
+
+    _emitMark();
+  } else {
+    _whenRouteDidChange.resolve();
+  }
 }
 
-export function setupRouter(router: Router): void {
+export function setupRouter(router: Router, options: SchedulerOptions): void {
   if (IS_FASTBOOT || (router as any)[APP_SCHEDULER_HAS_SETUP]) {
     return;
   }
 
   (router as any)[APP_SCHEDULER_HAS_SETUP] = true;
+
+  if (CAPABILITIES.performanceObserverEnabled) {
+    schedulerOptions = assign(DEFAULT_OPTIONS, options);
+
+    installObserver();
+  }
 
   if (gte('3.6.0')) {
     router.on('routeWillChange', beginTransition);
@@ -79,8 +141,6 @@ export function reset(): void {
   if (!IS_FASTBOOT) {
     _whenRouteDidChange.resolve();
   }
-
-  _activeScheduledTasks = 0;
 }
 
 /**
@@ -146,37 +206,28 @@ export function _getScheduleFn(
 }
 
 export function _setCapabilities(newCapabilities = CAPABILITIES): void {
-  _capabilities = newCapabilities;
+  _capabilities = assign({}, _capabilities, newCapabilities);
   _whenRoutePaintedScheduleFn = _getScheduleFn();
   _whenRouteIdleScheduleFn = _getScheduleFn(USE_REQUEST_IDLE_CALLBACK);
+}
+
+export function _setEmitMark(overrideEmitMark: Function = emitMark) {
+  _emitMark = overrideEmitMark;
 }
 
 _whenRoutePaintedScheduleFn = _getScheduleFn();
 _whenRouteIdleScheduleFn = _getScheduleFn(USE_REQUEST_IDLE_CALLBACK);
 
 function _afterNextPaint(scheduleFn: Function): Promise<any> {
-  let promise = new Promise(resolve => {
-    if (DEBUG) {
-      _activeScheduledTasks++;
-    }
+  let nextPaintToken = waiter.beginAsync();
 
+  return new Promise(resolve => {
     scheduleFn(() => {
       run.later(resolve, 0);
     });
+  }).finally(() => {
+    waiter.endAsync(nextPaintToken);
   });
-
-  if (DEBUG) {
-    promise = promise.finally(() => {
-      _activeScheduledTasks--;
-    });
-  }
-
-  return promise;
-}
-
-if (DEBUG) {
-  // wait until no active rafs
-  registerWaiter(() => _activeScheduledTasks === 0);
 }
 
 function _defer(label: string): Deferred {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,24 +12,18 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.18',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true,
-            }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {
               'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.8',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.8.0',
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@types/rsvp": "^4.0.2",
     "ember-cli-babel": "^7.1.3",
     "ember-cli-typescript": "^2.0.0",
-    "ember-compatibility-helpers": "^1.1.2"
+    "ember-compatibility-helpers": "^1.1.2",
+    "ember-test-waiters": "^1.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",
@@ -66,7 +67,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.7.1",
     "ember-load-initializers": "^2.0.0",
-    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-maybe-import-regenerator-for-testing": "^1.0.0",
     "ember-qunit": "^4.0.0",
     "ember-resolver": "^5.0.0",
     "ember-router-scroll": "^1.1.0",

--- a/tests/acceptance/custom-emit-mark-test.js
+++ b/tests/acceptance/custom-emit-mark-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentRouteName } from '@ember/test-helpers';
+import { setupRouter, reset } from 'ember-app-scheduler';
+
+module('Acceptance | when using custom emitMark tests', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.router = this.owner.lookup('router:main');
+    // DO NOT DO THIS! This is only necessary to test the app scheduler's router
+    // setup in conjunction with ember-cli-addon-docs' router setup.
+    this.router['__APP_SCHEDULER_HAS_SETUP__'] = false;
+
+    setupRouter(this.router, { emitMark: false });
+  });
+
+  hooks.afterEach(function() {
+    this.router['__APP_SCHEDULER_HAS_SETUP__'] = false;
+
+    setupRouter(this.router, { emitMark: true });
+
+    reset();
+  });
+
+  test('visiting route renders deferred content when using custom emitMark invocation', async function(assert) {
+    assert.expect(2);
+
+    await visit('/custom-emit-mark');
+
+    assert.equal(currentRouteName(), 'custom-emit-mark');
+    assert.dom('.only-after-custom-emit-marks').exists();
+  });
+});

--- a/tests/dummy/app/initializers/route-anchor-jump.js
+++ b/tests/dummy/app/initializers/route-anchor-jump.js
@@ -1,0 +1,32 @@
+import Route from '@ember/routing/route';
+import { schedule } from '@ember/runloop';
+
+/**
+ * This initializer is a temporary fix to unblock this repository from an
+ * issue (https://github.com/ember-learn/ember-cli-addon-docs/issues/417)
+ * originating in `ember-cli-addon-docs`. Once that repository
+ * publishes the fix, this file should be deleted.
+ */
+Route.reopen({
+  afterModel() {
+    if (typeof location !== 'undefined') {
+      const { hash } = location;
+      if (hash && hash.length) {
+        schedule('afterRender', null, () => {
+          const anchor = document.querySelector(`a[href="${hash}"`);
+          if (anchor) {
+            anchor.scrollIntoView();
+          }
+        });
+      }
+    }
+
+    return this._super(...arguments);
+  },
+});
+
+export function initialize() {}
+
+export default {
+  initialize,
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,6 +19,7 @@ Router.map(function() {
   this.route('content-paint');
   this.route('aborted-paint');
   this.route('both-painted');
+  this.route('custom-emit-mark');
 
   this.route('not-found', { path: '/*path' });
 });

--- a/tests/dummy/app/routes/custom-emit-mark.js
+++ b/tests/dummy/app/routes/custom-emit-mark.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
+import { emitMark } from 'ember-app-scheduler';
+
+export default Route.extend({
+  init() {
+    this._super(...arguments);
+
+    run.later(() => {
+      emitMark();
+    }, 2);
+  },
+});

--- a/tests/dummy/app/templates/custom-emit-mark.hbs
+++ b/tests/dummy/app/templates/custom-emit-mark.hbs
@@ -1,0 +1,5 @@
+<div class="custom-emit-marks">
+  {{#when-route-idle}}
+    <span class="only-after-custom-emit-marks">Custom emit marks</span>
+  {{/when-route-idle}}
+</div>

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { assign } from '@ember/polyfills';
 import {
   reset,
   whenRoutePainted,
@@ -12,6 +13,7 @@ import {
   _getScheduleFn,
   USE_REQUEST_IDLE_CALLBACK,
   SIMPLE_CALLBACK,
+  _setEmitMark,
 } from 'ember-app-scheduler/scheduler';
 
 const REQUEST_ANIMATION_FRAME = requestAnimationFrame;
@@ -25,223 +27,283 @@ module('Unit | Scheduler', function(hooks) {
     reset();
   });
 
-  test('whenRoutePainted resolves when transition ended', async function(assert) {
-    assert.expect(1);
+  [
+    {
+      moduleName: 'using PerformanceObserver',
+      capabilities: { performanceObserverEnabled: true },
+    },
+    {
+      moduleName: 'not using PerformanceObserver',
+      capabilities: { performanceObserverEnabled: false },
+    },
+  ].forEach(({ moduleName, capabilities }) => {
+    module(moduleName, function() {
+      test('whenRoutePainted resolves when transition ended', async function(assert) {
+        assert.expect(1);
 
-    beginTransition();
+        _setCapabilities(capabilities);
 
-    let routePainted = whenRoutePainted();
+        beginTransition();
 
-    endTransition();
+        let routePainted = whenRoutePainted();
 
-    await routePainted.then(() => {
-      assert.ok(true);
+        endTransition();
+
+        await routePainted.then(() => {
+          assert.ok(true);
+        });
+
+        await routeSettled();
+      });
+
+      test('whenRouteIdle resolves when transition ended', async function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(capabilities);
+
+        beginTransition();
+
+        let routeIdle = whenRouteIdle();
+
+        endTransition();
+
+        await routeIdle.then(() => {
+          assert.ok(true);
+        });
+
+        await routeSettled();
+      });
+
+      test('whenRoutePainted resolves when transition ended when requestAnimationFrame not available', async function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: false,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+
+        _setEmitMark(() => {
+          performance.mark('routeIdle');
+        });
+
+        window.requestAnimationFrame = callback => {
+          assert.ok(false, 'requestAnimationFrame was used');
+          callback();
+        };
+        window.requestIdleCallback = callback => {
+          assert.ok(false, 'requestIdleCallback was used');
+          callback();
+        };
+
+        beginTransition();
+
+        let routePainted = whenRoutePainted();
+
+        endTransition();
+
+        await routePainted.then(() => {
+          assert.ok(true);
+        });
+
+        _setEmitMark();
+
+        await routeSettled();
+      });
+
+      test('whenRouteIdle resolves when transition ended when requestAnimationFrame not available', async function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: false,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+
+        _setEmitMark(() => {
+          performance.mark('routeIdle');
+        });
+
+        window.requestAnimationFrame = callback => {
+          assert.ok(false, 'requestAnimationFrame was used');
+          callback();
+        };
+        window.requestIdleCallback = callback => {
+          assert.ok(false, 'requestIdleCallback was used');
+          callback();
+        };
+
+        beginTransition();
+
+        let routeIdle = whenRouteIdle();
+
+        endTransition();
+
+        await routeIdle.then(() => {
+          assert.ok(true);
+        });
+
+        _setEmitMark();
+
+        await routeSettled();
+      });
+
+      test('whenRoutePainted resolves using requestAnimationFrame when transition ended', async function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: true,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+
+        _setEmitMark(() => {
+          performance.mark('routeIdle');
+        });
+
+        window.requestAnimationFrame = callback => {
+          assert.ok(true, 'requestAnimationFrame was used');
+          callback();
+        };
+        window.requestIdleCallback = callback => {
+          assert.ok(false, 'requestIdleCallback was used');
+          callback();
+        };
+
+        beginTransition();
+
+        let routePainted = whenRoutePainted();
+
+        endTransition();
+
+        await routePainted.then(() => {
+          assert.ok(true);
+        });
+
+        _setEmitMark();
+
+        await routeSettled();
+      });
+
+      test('whenRouteIdle resolves using requestAnimationFrame when transition ended', async function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: true,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+
+        _setEmitMark(() => {
+          performance.mark('routeIdle');
+        });
+
+        window.requestAnimationFrame = callback => {
+          assert.ok(true, 'requestAnimationFrame was used');
+          callback();
+        };
+        window.requestIdleCallback = callback => {
+          assert.ok(false, 'requestIdleCallback was used');
+          callback();
+        };
+
+        beginTransition();
+
+        let routeIdle = whenRouteIdle();
+
+        endTransition();
+
+        await routeIdle.then(() => {
+          assert.ok(true);
+        });
+
+        _setEmitMark();
+
+        await routeSettled();
+      });
+
+      test('whenRoutePainted with transition interupted', async function(assert) {
+        assert.expect(3);
+
+        _setCapabilities(capabilities);
+
+        beginTransition();
+
+        whenRoutePainted().then(() => {
+          assert.step('first whenRoutePainted');
+        });
+
+        beginTransition();
+
+        whenRoutePainted().then(() => {
+          assert.step('second whenRoutePainted');
+        });
+
+        endTransition();
+
+        await routeSettled();
+
+        assert.verifySteps([
+          'first whenRoutePainted',
+          'second whenRoutePainted',
+        ]);
+      });
+
+      test('whenRouteIdle with transition interupted', async function(assert) {
+        assert.expect(3);
+
+        _setCapabilities(capabilities);
+
+        beginTransition();
+
+        whenRouteIdle().then(() => {
+          assert.step('first whenRouteIdle');
+        });
+
+        beginTransition();
+
+        whenRouteIdle().then(() => {
+          assert.step('second whenRouteIdle');
+        });
+
+        endTransition();
+
+        await routeSettled();
+
+        assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
+      });
+
+      test('_getScheduleFn falls back to requestAnimationFrame if requestIdleCallbackEnabled: not available', function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: true,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+        assert.equal(
+          _getScheduleFn(USE_REQUEST_IDLE_CALLBACK),
+          requestAnimationFrame
+        );
+      });
+
+      test('_getScheduleFn returns simple callback if requestAnimationFrame not available', function(assert) {
+        assert.expect(1);
+
+        _setCapabilities(
+          assign(capabilities, {
+            requestAnimationFrameEnabled: false,
+            requestIdleCallbackEnabled: false,
+          })
+        );
+
+        assert.equal(_getScheduleFn(), SIMPLE_CALLBACK);
+      });
     });
-
-    await routeSettled();
-  });
-
-  test('whenRouteIdle resolves when transition ended', async function(assert) {
-    assert.expect(1);
-
-    beginTransition();
-
-    let routeIdle = whenRouteIdle();
-
-    endTransition();
-
-    await routeIdle.then(() => {
-      assert.ok(true);
-    });
-
-    await routeSettled();
-  });
-
-  test('whenRoutePainted resolves when transition ended when requestAnimationFrame not available', async function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: false,
-      requestIdleCallbackEnabled: false,
-    });
-
-    window.requestAnimationFrame = callback => {
-      assert.ok(false, 'requestAnimationFrame was used');
-      callback();
-    };
-    window.requestIdleCallback = callback => {
-      assert.ok(false, 'requestIdleCallback was used');
-      callback();
-    };
-
-    beginTransition();
-
-    let routePainted = whenRoutePainted();
-
-    endTransition();
-
-    await routePainted.then(() => {
-      assert.ok(true);
-    });
-
-    await routeSettled();
-  });
-
-  test('whenRouteIdle resolves when transition ended when requestAnimationFrame not available', async function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: false,
-      requestIdleCallbackEnabled: false,
-    });
-
-    window.requestAnimationFrame = callback => {
-      assert.ok(false, 'requestAnimationFrame was used');
-      callback();
-    };
-    window.requestIdleCallback = callback => {
-      assert.ok(false, 'requestIdleCallback was used');
-      callback();
-    };
-
-    beginTransition();
-
-    let routeIdle = whenRouteIdle();
-
-    endTransition();
-
-    await routeIdle.then(() => {
-      assert.ok(true);
-    });
-
-    await routeSettled();
-  });
-
-  test('whenRoutePainted resolves using requestAnimationFrame when transition ended', async function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: true,
-      requestIdleCallbackEnabled: false,
-    });
-
-    window.requestAnimationFrame = callback => {
-      assert.ok(true, 'requestAnimationFrame was used');
-      callback();
-    };
-    window.requestIdleCallback = callback => {
-      assert.ok(false, 'requestIdleCallback was used');
-      callback();
-    };
-
-    beginTransition();
-
-    let routePainted = whenRoutePainted();
-
-    endTransition();
-
-    await routePainted.then(() => {
-      assert.ok(true);
-    });
-
-    await routeSettled();
-  });
-
-  test('whenRouteIdle resolves using requestAnimationFrame when transition ended', async function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: true,
-      requestIdleCallbackEnabled: false,
-    });
-
-    window.requestAnimationFrame = callback => {
-      assert.ok(true, 'requestAnimationFrame was used');
-      callback();
-    };
-    window.requestIdleCallback = callback => {
-      assert.ok(false, 'requestIdleCallback was used');
-      callback();
-    };
-
-    beginTransition();
-
-    let routeIdle = whenRouteIdle();
-
-    endTransition();
-
-    await routeIdle.then(() => {
-      assert.ok(true);
-    });
-
-    await routeSettled();
-  });
-
-  test('whenRoutePainted with transition interupted', async function(assert) {
-    assert.expect(3);
-
-    beginTransition();
-
-    whenRoutePainted().then(() => {
-      assert.step('first whenRoutePainted');
-    });
-
-    beginTransition();
-
-    whenRoutePainted().then(() => {
-      assert.step('second whenRoutePainted');
-    });
-
-    endTransition();
-
-    await routeSettled();
-
-    assert.verifySteps(['first whenRoutePainted', 'second whenRoutePainted']);
-  });
-
-  test('whenRouteIdle with transition interupted', async function(assert) {
-    assert.expect(3);
-
-    beginTransition();
-
-    whenRouteIdle().then(() => {
-      assert.step('first whenRouteIdle');
-    });
-
-    beginTransition();
-
-    whenRouteIdle().then(() => {
-      assert.step('second whenRouteIdle');
-    });
-
-    endTransition();
-
-    await routeSettled();
-
-    assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
-  });
-
-  test('_getScheduleFn falls back to requestAnimationFrame if requestIdleCallbackEnabled: not available', function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: true,
-      requestIdleCallbackEnabled: false,
-    });
-    assert.equal(
-      _getScheduleFn(USE_REQUEST_IDLE_CALLBACK),
-      requestAnimationFrame
-    );
-  });
-
-  test('_getScheduleFn returns simple callback if requestAnimationFrame not available', function(assert) {
-    assert.expect(1);
-
-    _setCapabilities({
-      requestAnimationFrameEnabled: false,
-      requestIdleCallbackEnabled: false,
-    });
-
-    assert.equal(_getScheduleFn(), SIMPLE_CALLBACK);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5236,9 +5236,11 @@ elliptic@^6.0.0:
 
 ember-app-scheduler@^1.0.5:
   version "0.0.0"
+  uid ""
 
 "ember-app-scheduler@link:./":
   version "0.0.0"
+  uid ""
 
 ember-assign-polyfill@^2.5.0, ember-assign-polyfill@^2.6.0:
   version "2.6.0"
@@ -6139,7 +6141,16 @@ ember-load-initializers@^2.0.0:
     ember-cli-babel "^7.10.0"
     ember-cli-typescript "^2.0.0"
 
-ember-maybe-import-regenerator@^0.1.5, ember-maybe-import-regenerator@^0.1.6:
+ember-maybe-import-regenerator-for-testing@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator-for-testing/-/ember-maybe-import-regenerator-for-testing-1.0.0.tgz#894b8089c5b3067c920b492c81233603852d5c2f"
+  integrity sha512-9ZOjrXZ6iO8WnVuk5kLqUZIFEEOx2O/EA08vcedaT/XSna6LzH2knLx5OiOD9f7XiO8jNaYuZoh0Uq3wnm8/oA==
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    ember-cli-babel "^6.6.0"
+    regenerator-runtime "^0.9.5"
+
+ember-maybe-import-regenerator@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
   integrity sha1-NdQYKK+m1qWbwNo85H80xXPXdso=
@@ -6299,6 +6310,13 @@ ember-test-waiters@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.0.0.tgz#6990daed15a31e4593dc153a33a20668f76abe5c"
   integrity sha512-0VP7oTTur/wm2///9EuMwg1/6KP6yRAamyP7DaiYfrY1js1vHtZU2fDPgjwuL0QL4FG1chyUiL/Gi3+dIaqQmA==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+
+ember-test-waiters@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.1.1.tgz#7df6e7a47e0fdca814aa351f7f7f9a006e15fdcd"
+  integrity sha512-ra71ZWTGBGLeDPa308aeAg9+/nYxv2fk4OEzmXdhvbSa5Dtbei94sr5pbLXx2IiK3Re2gDAvDzxg9PVhLy9fig==
   dependencies:
     ember-cli-babel "^7.1.2"
 


### PR DESCRIPTION
An issue was uncovered via instrumented trace events from `chrome-debugging-client`, which lead us to look a bit deeper about the implementation of this library.

Specifically, we noticed that deferred assets that were scheduled `whenRouteIdle` were non-deterministically rendered either before or after our page load marker our application emits. This seemed to imply that `requestIdleCallback` was not behaving the way we collectively thought. Our collective understanding was that `requestIdleCallback` would fire after render, and any remaining long tasks that were in flight on the main thread. After [looking at the spec](https://www.w3.org/TR/requestidlecallback/#idle-periods), it became clear to us that `requestIdleCallback` is frame based, meaning work will only execute based on any remaining time within a single frame. This meant that work that we were attempting to defer was actually being executed early, potentially impacting performance by doing non-critical work during the critical rendering path.

This PR changes _when_ the top level promise resolves, in that in browsers that support `PerformanceObserver`, we now install an observer and only resolve the promise at the observation of a mark, whether emitted from this addon itself, or a custom invocation. This means that we will truly be triggering work after a specific point of the page.