### PR TITLE
task(docs): Adding documentation for custom mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ember batches DOM updates and paints them after every run loop to prevent [layou
 
 As a way to mitigate the need to render all content at once regardless of its visual priority, some work done on the page like ads, analytics tracking, rendering non critical content, rendering content outside viewport etc. can be deferred to achieve a faster FMP. This work can be delayed to run after the FMP and achieve incremental rendering of the page.
 
-This addon provides a way to defer work into different paint phases of the rendering process to get a faster FMP. It also helps to prioritize and coordinate when the paint happens for different parts of the page.
+This addon provides a way to defer work into different phases of the rendering process to get a faster FMP. It also helps to prioritize and coordinate when the paint happens for different parts of the page.
 
 The [documentation website](https://ember-app-scheduler.github.io/ember-app-scheduler/) contains more examples and API information.
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -22,6 +22,7 @@ Router.map(function() {
   this.route('custom-emit-mark');
 
   this.route('not-found', { path: '/*path' });
+  this.route('custom-mark');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -8,6 +8,7 @@
       {{nav.item "How it works" "docs.how-it-works"}}
       {{nav.item "whenRoutePainted" "docs.when-route-painted"}}
       {{nav.item "whenRouteIdle" "docs.when-route-idle"}}
+      {{nav.item "Custom mark" "docs.custom-mark"}}
       {{nav.item "Testing" "docs.testing"}}
       {{nav.item "Fastboot" "docs.fastboot"}}
     {{/nav.subnav}}

--- a/tests/dummy/app/templates/docs/custom-mark.md
+++ b/tests/dummy/app/templates/docs/custom-mark.md
@@ -1,0 +1,22 @@
+# Custom mark
+
+The `ember-app-scheduler` addon, as part of is functionality, relies on a `performance.mark` being emitted, which signals to the library that the deferred work can be started. While the addon provides a default `performance.mark`, it also supports using a custom mark name, which can be used instead of the default.
+
+In order to configure `ember-app-scheduler` to use your custom mark, the following options are available to be passed as a second argument to the `setupRouter` function:
+
+```typescript
+interface SchedulerOptions {
+  markName: string;
+  emitMark: boolean;
+}
+```
+
+When using these custom options, pass the `markName` you want to use, and set the `emitMark` option to `false`:
+
+```js
+setupRouter(router, { markName: 'my-app-custom-mark', emitMark: false } );
+```
+
+This will allow `ember-app-scheduler` to execute the deferred work at a specific time of your choosing.
+
+> *NOTE*: You should ensure that your `performance.mark` call is invoked at a reasonably late time in the page load process, otherwise you could interfere with the normal rendering phase and ultimately adversely affect page load times. This is notoriously difficult to guage in an single page application. If you're unsure how to ensure your mark is emitted at the correct time, it's recommended that you fall back to `ember-app-scheduler`'s implementation.

--- a/tests/dummy/app/templates/docs/how-it-works.md
+++ b/tests/dummy/app/templates/docs/how-it-works.md
@@ -4,16 +4,41 @@ Ember batches DOM updates and paints them after every run loop to prevent [layou
 
 As a way to mitigate the need to render all content at once regardless of its visual priority, some work done on the page like ads, analytics tracking, rendering non critical content, rendering content outside viewport etc. can be deferred to achieve a faster FMP. This work can be delayed to run after the FMP and achieve incremental rendering of the page.
 
-This addon provides a way to defer work into different paint phases of the rendering process to get a faster FMP. It also helps to prioritize and coordinate when the paint happens for different parts of the page.
+This addon provides a way to defer work into different phases of the rendering process to get a faster FMP. It also helps to prioritize and coordinate when the paint happens for different parts of the page.
 
 ## Concept
 
 Because there isn't a concrete mechanism that allows us to determine when the page is meaningfully painted, it's necessary for us to approximate this. We do so by utilizing a combination of `requestAnimationFrame` calls, which we know have a fairly consistent point of execution (prior to styling, layout, and painting), and scheduling of a macro task using `setTimeout`. Since we know that scheduling a macro task will cause that macro task to be run in the JavaScript event loop _after_ the preceding `requestAnimationFrame` and subsequent paint phase, we can have some fairly dependable guarantees for when work can occur _following a paint_.
 
-To simply visualize what this looks like in relation to `ember-app-scheduler`'s APIs, this is how we accomplish what's described above:
+As of version 3.0, we have changed the execution semantics to be more deterministic when executing the `whenRoutePainted` and `whenRouteIdle` work. Since `requestAnimationFrame` and `requestIdleCallback` calls can still result in work being done earlier than desired, we added an extra mechanism that will help produce deterministic results: the observation of a specific `performance.mark`. By default, you don't need to concern yourself with the emission of the `performance.mark` call. However, if your app already emits a `performance.mark` at a location that reasonably denotes when work should commence, such as Page Load Time, then you can configure `ember-app-scheduler` to observe this mark instead of its default mark.
 
-`requestAnimationFrame` -> Schedule macro task (run.later(fn, 0)) -> browser paint -> macro task runs -> `whenRoutePainted` promise resolves
+To visualize what this looks like in relation to `ember-app-scheduler`'s APIs, this is how we accomplish what's described above:
 
-`requestAnimationFrame` -> Schedule macro task (run.later(fn, 0)) -> browser paint -> macro task runs -> `whenRouteIdle` promise resolves
+`whenRoutePainted`
+------------------
+
+When navigating to a route
+1. transition completes `didTransition`/`routeDidChange`
+1. `performance.mark` is emitted
+1. `PerformanceObserver.observe` observes the emitted mark, and resolves the top-level promise
+1. `requestAnimationFrame`
+1. Schedule macro task (`run.later(fn, 0)`)
+1. browser paint
+1. macro task runs
+1. `whenRoutePainted` promise resolves
+1. your work is exected in any thenables
+
+`whenRouteIdle`
+---------------
+
+1. transition completes `didTransition`/`routeDidChange`
+1. `performance.mark` is emitted
+1. `PerformanceObserver.observe` observes the emitted mark, and resolves the top-level promise
+1. `requestIdleCallback` (or `requestAnimationFrame` in browsers that don't support the former)
+1. Schedule macro task (`run.later(fn, 0)`)
+1. browser paint
+1. macro task runs
+1. `whenRouteIdle` promise resolves
+1. your work is exected in any thenables
 
 Each of the above are chained together to ensure ordering.


### PR DESCRIPTION
Adds documentation to describe how users can configure a custom `performance.mark`.