### PR TITLE
task(deprecate): Deprecates whenRoutePainted

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ You can then use one of the provided APIs to defer work.
 
 ### `whenRouteIdle`
 
-By deferring work until the route is idle, we delay non-critical work. To do this, you can import and use the `whenRouteIdle` function. This is useful for scenarios like rendering ads, scheduling tracking work, rendering of popup overlays etc.
+By deferring work until the route is idle (approximately after the first paint completes), we delay non-critical work. To do this, you can import and use the `whenRouteIdle` function. This is useful for scenarios like rendering ads, scheduling tracking work, rendering of popup overlays etc.
 
-In most cases, the `whenRouteIdle` function is all you need to defer work, though `ember-app-scheduler` does expose other functions as described below.
+In most cases, the `whenRouteIdle` function is all you need to defer work, though `ember-app-scheduler` does expose other functions.
 
 ```javascript
 import Route from '@ember/routing/route';

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -7,5 +7,5 @@ export {
   didTransition,
   whenRoutePainted,
   whenRouteIdle,
-  emitMark,
+  beginScheduledWork,
 } from 'ember-app-scheduler/scheduler';

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -7,5 +7,4 @@ export {
   didTransition,
   whenRoutePainted,
   whenRouteIdle,
-  beginScheduledWork,
 } from 'ember-app-scheduler/scheduler';

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -36,7 +36,7 @@ let _emitMark: Function = emitMark;
 
 reset();
 
-function installObserver() {
+function _installObserver() {
   if (PERFORMANCE_OBSERVER_SETUP) {
     return;
   }
@@ -91,7 +91,7 @@ export function setupRouter(router: Router): void {
   (router as any)[APP_SCHEDULER_HAS_SETUP] = true;
 
   if (CAPABILITIES.performanceObserverEnabled) {
-    installObserver();
+    _installObserver();
   }
 
   if (gte('3.6.0')) {

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -1,7 +1,6 @@
 import { Promise } from 'rsvp';
 import { schedule } from '@ember/runloop';
 import { deprecate } from '@ember/debug';
-import { assign } from '@ember/polyfills';
 import Router from '@ember/routing/router';
 import { gte } from 'ember-compatibility-helpers';
 import { buildWaiter, Token } from 'ember-test-waiters';
@@ -13,20 +12,11 @@ interface Deferred {
   reject: Function;
 }
 
-interface Capabilities {
-  requestAnimationFrameEnabled: boolean;
-}
-
 const APP_SCHEDULER_LABEL: string = 'ember-app-scheduler';
 const APP_SCHEDULER_HAS_SETUP: string = '__APP_SCHEDULER_HAS_SETUP__';
 
 let _whenRouteDidChange: Deferred;
 let _whenRouteIdle: Promise<any>;
-const CAPABILITIES: Capabilities = {
-  requestAnimationFrameEnabled: typeof requestAnimationFrame === 'function',
-};
-
-let _capabilities = CAPABILITIES;
 
 export const SIMPLE_CALLBACK = (callback: Function) => callback();
 const IS_FASTBOOT = typeof (<any>window).FastBoot !== 'undefined';
@@ -57,11 +47,7 @@ export function beginTransition(): void {
 }
 
 export function endTransition(): void {
-  if (CAPABILITIES.requestAnimationFrameEnabled) {
-    beginScheduledWork();
-  } else {
-    _whenRouteDidChange.resolve();
-  }
+  beginScheduledWork();
 }
 
 export function setupRouter(router: Router): void {
@@ -138,10 +124,6 @@ export function whenRouteIdle(): Promise<any> {
  */
 export function routeSettled(): Promise<any> {
   return _whenRouteIdle;
-}
-
-export function _setCapabilities(newCapabilities = CAPABILITIES): void {
-  _capabilities = assign({}, _capabilities, newCapabilities);
 }
 
 function _defer(label: string): Deferred {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "resolutions": {
     "@types/ember__object": "~3.0.6",
     "@types/ember__component": "~3.0.4",
+    "@types/ember__debug": "~3.0.6",
     "@types/ember__routing": "~3.0.6",
     "@types/ember__error": "~3.0.2",
     "**/ember-app-scheduler": "link:./",

--- a/testem.js
+++ b/testem.js
@@ -2,7 +2,7 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome'],
+  launch_in_dev: ['Chrome', 'Firefox'],
   browser_args: {
     Chrome: {
       ci: [

--- a/testem.js
+++ b/testem.js
@@ -1,8 +1,8 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome', 'Firefox'],
+  launch_in_ci: ['Chrome', 'Firefox'],
+  launch_in_dev: ['Chrome'],
   browser_args: {
     Chrome: {
       ci: [
@@ -15,6 +15,9 @@ module.exports = {
         '--remote-debugging-port=0',
         '--window-size=1440,900',
       ].filter(Boolean),
+    },
+    Firefox: {
+      ci: ['-headless'],
     },
   },
 };

--- a/tests/acceptance/deferred-render-test.js
+++ b/tests/acceptance/deferred-render-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, currentRouteName } from '@ember/test-helpers';
+import { visit, currentRouteName, click } from '@ember/test-helpers';
 import { setupRouter, reset } from 'ember-app-scheduler';
 
 module('Acceptance | when rendered tests', function(hooks) {
@@ -51,5 +51,17 @@ module('Acceptance | when rendered tests', function(hooks) {
 
     assert.equal(currentRouteName(), 'first-paint');
     assert.dom('.only-when-route-painted').exists();
+  });
+
+  test('visiting route and transitioning to another renders deferred content via both whenRoutePainted and whenRouteIdle', async function(assert) {
+    assert.expect(3);
+
+    await visit('/content-paint');
+
+    await click('a');
+
+    assert.equal(currentRouteName(), 'both-painted');
+    assert.dom('.only-when-route-painted').exists();
+    assert.dom('.only-when-route-idle').exists();
   });
 });

--- a/tests/dummy/app/templates/content-paint.hbs
+++ b/tests/dummy/app/templates/content-paint.hbs
@@ -2,4 +2,6 @@
   {{#when-route-idle}}
     <span class="only-when-route-idle">When Route Idle</span>
   {{/when-route-idle}}
+
+  {{#link-to "both-painted"}}Go to both painted{{/link-to}}
 </div>

--- a/tests/dummy/app/templates/docs/how-it-works.md
+++ b/tests/dummy/app/templates/docs/how-it-works.md
@@ -12,8 +12,6 @@ Because there isn't a concrete mechanism that allows us to determine when the pa
 
 To simply visualize what this looks like in relation to `ember-app-scheduler`'s APIs, this is how we accomplish what's described above:
 
-`schedule('afterRender')` -> `requestAnimationFrame` -> `requestAnimationFrame` -> browser paint -> `whenRoutePainted` promise resolves
-
 `schedule('afterRender')` -> `requestAnimationFrame` -> `requestAnimationFrame` -> browser paint -> `whenRouteIdle` promise resolves
 
 Each of the above are chained together to ensure ordering.

--- a/tests/dummy/app/templates/docs/how-it-works.md
+++ b/tests/dummy/app/templates/docs/how-it-works.md
@@ -8,12 +8,12 @@ This addon provides a way to defer work into different paint phases of the rende
 
 ## Concept
 
-Because there isn't a concrete mechanism that allows us to determine when the page is meaningfully painted, it's necessary for us to approximate this. We do so by utilizing a combination of `requestAnimationFrame` calls, which we know have a fairly consistent point of execution (prior to styling, layout, and painting), and scheduling of a macro task using `setTimeout`. Since we know that scheduling a macro task will cause that macro task to be run in the JavaScript event loop _after_ the preceding `requestAnimationFrame` and subsequent paint phase, we can have some fairly dependable guarantees for when work can occur _following a paint_.
+Because there isn't a concrete mechanism that allows us to determine when the page is meaningfully painted, it's necessary for us to approximate this. We do so by utilizing a combination of scheduling an `afterRender` and `requestAnimationFrame` calls, which we know have a fairly consistent point of execution (prior to styling, layout, and painting). Since we know that scheduling successive `requestAnimationFrame` calls following the initial render, we can have some fairly dependable guarantees for when work can occur _following a paint_.
 
 To simply visualize what this looks like in relation to `ember-app-scheduler`'s APIs, this is how we accomplish what's described above:
 
-`requestAnimationFrame` -> Schedule macro task (run.later(fn, 0)) -> browser paint -> macro task runs -> `whenRoutePainted` promise resolves
+`schedule('afterRender')` -> `requestAnimationFrame` -> `requestAnimationFrame` -> browser paint -> `whenRoutePainted` promise resolves
 
-`requestAnimationFrame` -> Schedule macro task (run.later(fn, 0)) -> browser paint -> macro task runs -> `whenRouteIdle` promise resolves
+`schedule('afterRender')` -> `requestAnimationFrame` -> `requestAnimationFrame` -> browser paint -> `whenRouteIdle` promise resolves
 
 Each of the above are chained together to ensure ordering.

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -6,99 +6,47 @@ import {
   beginTransition,
   endTransition,
 } from 'ember-app-scheduler';
-import { _setCapabilities } from 'ember-app-scheduler/scheduler';
 
 module('Unit | Scheduler', function(hooks) {
   hooks.afterEach(function() {
-    _setCapabilities();
     reset();
   });
 
-  module('using requestAnimationFrame', function() {
-    test('whenRouteIdle resolves when transition ended', async function(assert) {
-      assert.expect(1);
+  test('whenRouteIdle resolves when transition ended', async function(assert) {
+    assert.expect(1);
 
-      _setCapabilities({ requestAnimationFrameEnabled: true });
+    beginTransition();
 
-      beginTransition();
+    let routeIdle = whenRouteIdle();
 
-      let routeIdle = whenRouteIdle();
+    endTransition();
 
-      endTransition();
-
-      await routeIdle.then(() => {
-        assert.ok(true);
-      });
-
-      await routeSettled();
+    await routeIdle.then(() => {
+      assert.ok(true);
     });
 
-    test('whenRouteIdle with transition interupted', async function(assert) {
-      assert.expect(3);
-
-      _setCapabilities({ requestAnimationFrameEnabled: true });
-
-      beginTransition();
-
-      whenRouteIdle().then(() => {
-        assert.step('first whenRouteIdle');
-      });
-
-      beginTransition();
-
-      whenRouteIdle().then(() => {
-        assert.step('second whenRouteIdle');
-      });
-
-      endTransition();
-
-      await routeSettled();
-
-      assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
-    });
+    await routeSettled();
   });
 
-  module('not using requestAnimationFrame', function() {
-    test('whenRouteIdle resolves when transition ended', async function(assert) {
-      assert.expect(1);
+  test('whenRouteIdle with transition interupted', async function(assert) {
+    assert.expect(3);
 
-      _setCapabilities({ requestAnimationFrameEnabled: false });
+    beginTransition();
 
-      beginTransition();
-
-      let routeIdle = whenRouteIdle();
-
-      endTransition();
-
-      await routeIdle.then(() => {
-        assert.ok(true);
-      });
-
-      await routeSettled();
+    whenRouteIdle().then(() => {
+      assert.step('first whenRouteIdle');
     });
 
-    test('whenRouteIdle with transition interupted', async function(assert) {
-      assert.expect(3);
+    beginTransition();
 
-      _setCapabilities({ requestAnimationFrameEnabled: false });
-
-      beginTransition();
-
-      whenRouteIdle().then(() => {
-        assert.step('first whenRouteIdle');
-      });
-
-      beginTransition();
-
-      whenRouteIdle().then(() => {
-        assert.step('second whenRouteIdle');
-      });
-
-      endTransition();
-
-      await routeSettled();
-
-      assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
+    whenRouteIdle().then(() => {
+      assert.step('second whenRouteIdle');
     });
+
+    endTransition();
+
+    await routeSettled();
+
+    assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
   });
 });

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -1,309 +1,104 @@
 import { module, test } from 'qunit';
-import { assign } from '@ember/polyfills';
 import {
   reset,
-  whenRoutePainted,
   whenRouteIdle,
   routeSettled,
   beginTransition,
   endTransition,
 } from 'ember-app-scheduler';
-import {
-  _setCapabilities,
-  _getScheduleFn,
-  USE_REQUEST_IDLE_CALLBACK,
-  SIMPLE_CALLBACK,
-  _setEmitMark,
-} from 'ember-app-scheduler/scheduler';
-
-const REQUEST_ANIMATION_FRAME = requestAnimationFrame;
-const REQUEST_IDLE_CALLBACK = requestIdleCallback;
+import { _setCapabilities } from 'ember-app-scheduler/scheduler';
 
 module('Unit | Scheduler', function(hooks) {
   hooks.afterEach(function() {
-    window.requestAnimationFrame = REQUEST_ANIMATION_FRAME;
-    window.requestIdleCallback = REQUEST_IDLE_CALLBACK;
     _setCapabilities();
     reset();
   });
 
-  [
-    {
-      moduleName: 'using PerformanceObserver',
-      capabilities: { performanceObserverEnabled: true },
-    },
-    {
-      moduleName: 'not using PerformanceObserver',
-      capabilities: { performanceObserverEnabled: false },
-    },
-  ].forEach(({ moduleName, capabilities }) => {
-    module(moduleName, function() {
-      test('whenRoutePainted resolves when transition ended', async function(assert) {
-        assert.expect(1);
+  module('using PerformanceObserver', function() {
+    test('whenRouteIdle resolves when transition ended', async function(assert) {
+      assert.expect(1);
 
-        _setCapabilities(capabilities);
+      _setCapabilities({ performanceObserverEnabled: true });
 
-        beginTransition();
+      beginTransition();
 
-        let routePainted = whenRoutePainted();
+      let routeIdle = whenRouteIdle();
 
-        endTransition();
+      endTransition();
 
-        await routePainted.then(() => {
-          assert.ok(true);
-        });
-
-        await routeSettled();
+      await routeIdle.then(() => {
+        assert.ok(true);
       });
 
-      test('whenRouteIdle resolves when transition ended', async function(assert) {
-        assert.expect(1);
+      await routeSettled();
+    });
 
-        _setCapabilities(capabilities);
+    test('whenRouteIdle with transition interupted', async function(assert) {
+      assert.expect(3);
 
-        beginTransition();
+      _setCapabilities({ performanceObserverEnabled: true });
 
-        let routeIdle = whenRouteIdle();
+      beginTransition();
 
-        endTransition();
-
-        await routeIdle.then(() => {
-          assert.ok(true);
-        });
-
-        await routeSettled();
+      whenRouteIdle().then(() => {
+        assert.step('first whenRouteIdle');
       });
 
-      test('whenRoutePainted resolves when transition ended when requestAnimationFrame not available', async function(assert) {
-        assert.expect(1);
+      beginTransition();
 
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: false,
-            requestIdleCallbackEnabled: false,
-          })
-        );
-
-        _setEmitMark(() => {
-          performance.mark('routeIdle');
-        });
-
-        window.requestAnimationFrame = callback => {
-          assert.ok(false, 'requestAnimationFrame was used');
-          callback();
-        };
-        window.requestIdleCallback = callback => {
-          assert.ok(false, 'requestIdleCallback was used');
-          callback();
-        };
-
-        beginTransition();
-
-        let routePainted = whenRoutePainted();
-
-        endTransition();
-
-        await routePainted.then(() => {
-          assert.ok(true);
-        });
-
-        _setEmitMark();
-
-        await routeSettled();
+      whenRouteIdle().then(() => {
+        assert.step('second whenRouteIdle');
       });
 
-      test('whenRouteIdle resolves when transition ended when requestAnimationFrame not available', async function(assert) {
-        assert.expect(1);
+      endTransition();
 
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: false,
-            requestIdleCallbackEnabled: false,
-          })
-        );
+      await routeSettled();
 
-        _setEmitMark(() => {
-          performance.mark('routeIdle');
-        });
+      assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
+    });
+  });
 
-        window.requestAnimationFrame = callback => {
-          assert.ok(false, 'requestAnimationFrame was used');
-          callback();
-        };
-        window.requestIdleCallback = callback => {
-          assert.ok(false, 'requestIdleCallback was used');
-          callback();
-        };
+  module('not using PerformanceObserver', function() {
+    test('whenRouteIdle resolves when transition ended', async function(assert) {
+      assert.expect(1);
 
-        beginTransition();
+      _setCapabilities({ performanceObserverEnabled: false });
 
-        let routeIdle = whenRouteIdle();
+      beginTransition();
 
-        endTransition();
+      let routeIdle = whenRouteIdle();
 
-        await routeIdle.then(() => {
-          assert.ok(true);
-        });
+      endTransition();
 
-        _setEmitMark();
-
-        await routeSettled();
+      await routeIdle.then(() => {
+        assert.ok(true);
       });
 
-      test('whenRoutePainted resolves using requestAnimationFrame when transition ended', async function(assert) {
-        assert.expect(1);
+      await routeSettled();
+    });
 
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: true,
-            requestIdleCallbackEnabled: false,
-          })
-        );
+    test('whenRouteIdle with transition interupted', async function(assert) {
+      assert.expect(3);
 
-        _setEmitMark(() => {
-          performance.mark('routeIdle');
-        });
+      _setCapabilities({ performanceObserverEnabled: false });
 
-        window.requestAnimationFrame = callback => {
-          assert.ok(true, 'requestAnimationFrame was used');
-          callback();
-        };
-        window.requestIdleCallback = callback => {
-          assert.ok(false, 'requestIdleCallback was used');
-          callback();
-        };
+      beginTransition();
 
-        beginTransition();
-
-        let routePainted = whenRoutePainted();
-
-        endTransition();
-
-        await routePainted.then(() => {
-          assert.ok(true);
-        });
-
-        _setEmitMark();
-
-        await routeSettled();
+      whenRouteIdle().then(() => {
+        assert.step('first whenRouteIdle');
       });
 
-      test('whenRouteIdle resolves using requestAnimationFrame when transition ended', async function(assert) {
-        assert.expect(1);
+      beginTransition();
 
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: true,
-            requestIdleCallbackEnabled: false,
-          })
-        );
-
-        _setEmitMark(() => {
-          performance.mark('routeIdle');
-        });
-
-        window.requestAnimationFrame = callback => {
-          assert.ok(true, 'requestAnimationFrame was used');
-          callback();
-        };
-        window.requestIdleCallback = callback => {
-          assert.ok(false, 'requestIdleCallback was used');
-          callback();
-        };
-
-        beginTransition();
-
-        let routeIdle = whenRouteIdle();
-
-        endTransition();
-
-        await routeIdle.then(() => {
-          assert.ok(true);
-        });
-
-        _setEmitMark();
-
-        await routeSettled();
+      whenRouteIdle().then(() => {
+        assert.step('second whenRouteIdle');
       });
 
-      test('whenRoutePainted with transition interupted', async function(assert) {
-        assert.expect(3);
+      endTransition();
 
-        _setCapabilities(capabilities);
+      await routeSettled();
 
-        beginTransition();
-
-        whenRoutePainted().then(() => {
-          assert.step('first whenRoutePainted');
-        });
-
-        beginTransition();
-
-        whenRoutePainted().then(() => {
-          assert.step('second whenRoutePainted');
-        });
-
-        endTransition();
-
-        await routeSettled();
-
-        assert.verifySteps([
-          'first whenRoutePainted',
-          'second whenRoutePainted',
-        ]);
-      });
-
-      test('whenRouteIdle with transition interupted', async function(assert) {
-        assert.expect(3);
-
-        _setCapabilities(capabilities);
-
-        beginTransition();
-
-        whenRouteIdle().then(() => {
-          assert.step('first whenRouteIdle');
-        });
-
-        beginTransition();
-
-        whenRouteIdle().then(() => {
-          assert.step('second whenRouteIdle');
-        });
-
-        endTransition();
-
-        await routeSettled();
-
-        assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
-      });
-
-      test('_getScheduleFn falls back to requestAnimationFrame if requestIdleCallbackEnabled: not available', function(assert) {
-        assert.expect(1);
-
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: true,
-            requestIdleCallbackEnabled: false,
-          })
-        );
-        assert.equal(
-          _getScheduleFn(USE_REQUEST_IDLE_CALLBACK),
-          requestAnimationFrame
-        );
-      });
-
-      test('_getScheduleFn returns simple callback if requestAnimationFrame not available', function(assert) {
-        assert.expect(1);
-
-        _setCapabilities(
-          assign(capabilities, {
-            requestAnimationFrameEnabled: false,
-            requestIdleCallbackEnabled: false,
-          })
-        );
-
-        assert.equal(_getScheduleFn(), SIMPLE_CALLBACK);
-      });
+      assert.verifySteps(['first whenRouteIdle', 'second whenRouteIdle']);
     });
   });
 });

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -14,11 +14,11 @@ module('Unit | Scheduler', function(hooks) {
     reset();
   });
 
-  module('using PerformanceObserver', function() {
+  module('using requestAnimationFrame', function() {
     test('whenRouteIdle resolves when transition ended', async function(assert) {
       assert.expect(1);
 
-      _setCapabilities({ performanceObserverEnabled: true });
+      _setCapabilities({ requestAnimationFrameEnabled: true });
 
       beginTransition();
 
@@ -36,7 +36,7 @@ module('Unit | Scheduler', function(hooks) {
     test('whenRouteIdle with transition interupted', async function(assert) {
       assert.expect(3);
 
-      _setCapabilities({ performanceObserverEnabled: true });
+      _setCapabilities({ requestAnimationFrameEnabled: true });
 
       beginTransition();
 
@@ -58,11 +58,11 @@ module('Unit | Scheduler', function(hooks) {
     });
   });
 
-  module('not using PerformanceObserver', function() {
+  module('not using requestAnimationFrame', function() {
     test('whenRouteIdle resolves when transition ended', async function(assert) {
       assert.expect(1);
 
-      _setCapabilities({ performanceObserverEnabled: false });
+      _setCapabilities({ requestAnimationFrameEnabled: false });
 
       beginTransition();
 
@@ -80,7 +80,7 @@ module('Unit | Scheduler', function(hooks) {
     test('whenRouteIdle with transition interupted', async function(assert) {
       assert.expect(3);
 
-      _setCapabilities({ performanceObserverEnabled: false });
+      _setCapabilities({ requestAnimationFrameEnabled: false });
 
       beginTransition();
 

--- a/tests/unit/scheduler-test.js
+++ b/tests/unit/scheduler-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import {
   reset,
+  whenRoutePainted,
   whenRouteIdle,
   routeSettled,
   beginTransition,
@@ -10,6 +11,44 @@ import {
 module('Unit | Scheduler', function(hooks) {
   hooks.afterEach(function() {
     reset();
+  });
+
+  test('whenRoutePainted resolves when transition ended', async function(assert) {
+    assert.expect(1);
+
+    beginTransition();
+
+    let routePainted = whenRoutePainted();
+
+    endTransition();
+
+    await routePainted.then(() => {
+      assert.ok(true);
+    });
+
+    await routeSettled();
+  });
+
+  test('whenRoutePainted with transition interupted', async function(assert) {
+    assert.expect(3);
+
+    beginTransition();
+
+    whenRoutePainted().then(() => {
+      assert.step('first whenRoutePainted');
+    });
+
+    beginTransition();
+
+    whenRoutePainted().then(() => {
+      assert.step('second whenRoutePainted');
+    });
+
+    endTransition();
+
+    await routeSettled();
+
+    assert.verifySteps(['first whenRoutePainted', 'second whenRoutePainted']);
   });
 
   test('whenRouteIdle resolves when transition ended', async function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   dependencies:
     "@types/ember__object" "*"
 
-"@types/ember__debug@*":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-3.0.4.tgz#cdf87a580688a0e3053820eff6f390fbb7ba0e80"
-  integrity sha512-jTdLdNGvDn3MhktfskhdxOaDHO09QtQqeh+krI7EDePl2+Xom+KnNeveFeCkzxDkYOa+/R7UNSxW4yN/3YTw3w==
+"@types/ember__debug@*", "@types/ember__debug@~3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-3.0.6.tgz#fa8bbc58249d8bdeea9be5b4ab8e974b33c39b07"
+  integrity sha512-he07ArVIGzXw79NDEePawpkQSmiDc9C6Z/K6MkD2sUJdVSFaggGXBKvGh/QdenaP8hdYz36/umXGabq/Z862SA==
   dependencies:
     "@types/ember__debug" "*"
     "@types/ember__engine" "*"
@@ -5284,9 +5284,11 @@ elliptic@^6.0.0:
 
 ember-app-scheduler@^1.0.5:
   version "0.0.0"
+  uid ""
 
 "ember-app-scheduler@link:./":
   version "0.0.0"
+  uid ""
 
 ember-assign-polyfill@^2.5.0, ember-assign-polyfill@^2.6.0:
   version "2.6.0"


### PR DESCRIPTION
Since we've modified the implementation to move away from successive rAF calls for targeting different parts of the paint phase in favor of resolving a promise immediately following a transition (with some delays), there's no longer any need for this intermediate paint API.

This PR is the first step at deprecating this API.