### PR TITLE
task(test waiters): Update to new ember-test-waiters

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -4,7 +4,7 @@ import { run } from '@ember/runloop';
 import Router from '@ember/routing/router';
 import { DEBUG } from '@glimmer/env';
 import { gte } from 'ember-compatibility-helpers';
-import { buildWaiter, Token } from 'ember-test-waiters';
+import { buildWaiter, Token, TestWaiter } from 'ember-test-waiters';
 
 interface Deferred {
   isResolved: boolean;
@@ -83,6 +83,8 @@ export function reset(): void {
   _whenRouteDidChange = _defer(APP_SCHEDULER_LABEL);
   _whenRoutePainted = _whenRouteDidChange.promise.then();
   _whenRouteIdle = _whenRoutePainted.then();
+
+  (<TestWaiter>waiter).items.clear();
 
   if (!IS_FASTBOOT) {
     _whenRouteDidChange.resolve();

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@types/rsvp": "^4.0.2",
     "ember-cli-babel": "^7.1.3",
     "ember-cli-typescript": "^2.0.0",
-    "ember-compatibility-helpers": "^1.1.2"
+    "ember-compatibility-helpers": "^1.1.2",
+    "ember-test-waiters": "^1.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6221,6 +6221,13 @@ ember-test-waiters@^1.0.0:
   dependencies:
     ember-cli-babel "^7.1.2"
 
+ember-test-waiters@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.1.1.tgz#7df6e7a47e0fdca814aa351f7f7f9a006e15fdcd"
+  integrity sha512-ra71ZWTGBGLeDPa308aeAg9+/nYxv2fk4OEzmXdhvbSa5Dtbei94sr5pbLXx2IiK3Re2gDAvDzxg9PVhLy9fig==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+
 ember-tether@^1.0.0-beta.2:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-tether/-/ember-tether-1.0.0.tgz#6117ea7351927887cb74fa5d46097dd300280c2d"


### PR DESCRIPTION
Converts to new test waiters to avoid situations where the `_activeScheduledTasks` could be reset in an aborted transition, and the waiter could be left in an inconsistent state, resulting in `settled` hanging and causing test timeouts.