### PR TITLE
Safely reset test waiters.

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -70,7 +70,9 @@ export function reset(): void {
   _whenRouteDidChange = _defer(APP_SCHEDULER_LABEL);
   _whenRouteIdle = _whenRouteDidChange.promise.then();
 
-  (<TestWaiter>waiter).items.clear();
+  if (waiter instanceof TestWaiter) {
+    waiter.items.clear();
+  }
 
   if (!IS_FASTBOOT) {
     _whenRouteDidChange.resolve();


### PR DESCRIPTION
The test waiters are not guaranteed to have `items`; instead of doing a cast (unsafe) use an `instanceof` check to determine whether we have an instance that *can* be cleared.