### PR TITLE
Safely reset test waiters.

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -80,7 +80,9 @@ export function reset(): void {
   _whenRoutePainted = _whenRouteDidChange.promise.then();
   _whenRouteIdle = _whenRoutePainted.then();
 
-  (<TestWaiter>waiter).items.clear();
+  if (waiter instanceof TestWaiter) {
+    waiter.items.clear();
+  }
 
   if (!IS_FASTBOOT) {
     _whenRouteDidChange.resolve();


### PR DESCRIPTION
The test waiters are not guaranteed to have `items`; instead of doing a cast (unsafe) use an `instanceof` check to determine whether we have an instance that *can* be cleared.

(Backport of #503 to v2.1.x)