### PR TITLE
Adding embroider tests to testing metrics

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -76,6 +76,16 @@ module.exports = async function() {
           },
         },
       },
+      {
+        name: 'embroider-tests',
+        npm: {
+          devDependencies: {
+            '@embroider/core': '*',
+            '@embroider/webpack': '*',
+            '@embroider/compat': '*',
+          },
+        },
+      },
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,12 +7,20 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  /*
-    This build file specifies the options for the dummy test app of this
-    addon, located in `/tests/dummy`
-    This build file does *not* influence how the addon or the app using it
-    behave. You most likely want to be modifying `./index.js` or app's build file
-  */
-
-  return app.toTree();
+  // Build with embroider when embroider is installed
+  if ('@embroider/webpack' in app.dependencies()) {
+    const {
+      Webpack
+    } = require('@embroider/webpack'); // eslint-disable-line node/no-missing-require
+    return require('@embroider/compat') // eslint-disable-line node/no-missing-require
+      .compatBuild(app, Webpack, {
+        packagerOptions: {
+          webpackConfig: {
+            devtool: false,
+          },
+        },
+      });
+  } else {
+    return app.toTree();
+  }
 };


### PR DESCRIPTION
ember-cli-addon-docs need to be deployed 
https://github.com/ember-learn/ember-cli-addon-docs/pull/474

After ember-cli-addon-docs are updated the next errors.

@ef4 It looks like a few addons are picking up `@babel/plugin-proposal-optional-chaining`
Resolving to a single version in the package.json does not fix the issue.
 
```
ERROR Summary:
  - broccoliBuilderErrorStack: ModuleBuildError: Module build failed (from /Users/kiwi/projects/ember-app-scheduler/node_modules/thread-loader/dist/cjs.js):
Thread Loader (Worker 0)
Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]

Duplicates detected are:
[
  {
    "alias": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
    "dirname": "/Users/kiwi/projects/ember-app-scheduler",
    "ownPass": false,
    "file": {
      "request": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
      "resolved": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js"
    }
  },
  {
    "alias": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
    "dirname": "/Users/kiwi/projects/ember-app-scheduler",
    "ownPass": false,
    "file": {
      "request": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js",
      "resolved": "/Users/kiwi/projects/ember-app-scheduler/node_modules/@babel/plugin-proposal-optional-chaining/lib/index.js"
    }
  }
]
```


