### PR TITLE
Recompute route-idle helper on transition change

### DIFF
--- a/addon/helpers/route-idle.js
+++ b/addon/helpers/route-idle.js
@@ -1,9 +1,22 @@
 import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { whenRouteIdle } from '../scheduler';
 
 export default class RouteIdle extends Helper {
+  @service router;
+
   @tracked isIdle = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.router.on('routeWillChange', () => {
+      if (!this.isDestroying) {
+        this.isIdle = false;
+      }
+    });
+  }
 
   compute() {
     if (this.isIdle) {
@@ -11,7 +24,9 @@ export default class RouteIdle extends Helper {
     }
 
     whenRouteIdle().then(() => {
-      this.isIdle = true;
+      if (!this.isDestroying) {
+        this.isIdle = true;
+      }
     });
 
     return false;

--- a/addon/helpers/route-idle.js
+++ b/addon/helpers/route-idle.js
@@ -1,34 +1,8 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
-import { whenRouteIdle } from '../scheduler';
+import scheduler from '../scheduler';
 
 export default class RouteIdle extends Helper {
-  @service router;
-
-  @tracked isIdle = false;
-
-  constructor() {
-    super(...arguments);
-
-    this.router.on('routeWillChange', () => {
-      if (!this.isDestroying) {
-        this.isIdle = false;
-      }
-    });
-  }
-
   compute() {
-    if (this.isIdle) {
-      return true;
-    }
-
-    whenRouteIdle().then(() => {
-      if (!this.isDestroying) {
-        this.isIdle = true;
-      }
-    });
-
-    return false;
+    return scheduler.isIdle;
   }
 }

--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -22,7 +22,6 @@ const APP_SCHEDULER_HAS_SETUP: string = '__APP_SCHEDULER_HAS_SETUP__';
 let _whenRouteDidChange: Deferred;
 let _whenRouteIdle: Promise<unknown>;
 
-export const SIMPLE_CALLBACK = (callback: Function) => callback();
 const IS_FASTBOOT = typeof (<any>window).FastBoot !== 'undefined';
 const waiter = buildWaiter('ember-app-scheduler-waiter');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-app-scheduler",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Ember addon to schedule work at different phases of app life cycle.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-app-scheduler",
-  "version": "6.0.0",
+  "version": "5.1.0",
   "description": "Ember addon to schedule work at different phases of app life cycle.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/controllers/route-idle-helper.js
+++ b/tests/dummy/app/controllers/route-idle-helper.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class RouteIdleHelperController extends Controller {
+  queryParams = ['refresh'];
+
+  @tracked refresh = 0;
+
+  @action
+  updateRefreshQP() {
+    this.refresh += 1;
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,8 +7,8 @@ const Router = AddonDocsRouter.extend(RouterScroll, {
   rootURL: config.rootURL,
 });
 
-Router.map(function() {
-  docsRoute(this, function() {
+Router.map(function () {
+  docsRoute(this, function () {
     this.route('how-it-works');
     this.route('when-route-painted');
     this.route('when-route-idle');
@@ -20,6 +20,7 @@ Router.map(function() {
   this.route('content-paint');
   this.route('aborted-paint');
   this.route('both-painted');
+  this.route('route-idle-helper');
 
   this.route('not-found', { path: '/*path' });
 });

--- a/tests/dummy/app/routes/route-idle-helper.js
+++ b/tests/dummy/app/routes/route-idle-helper.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+import { Promise } from 'rsvp';
+
+export default class RouteIdleHelperRoute extends Route {
+  queryParams = {
+    refresh: {
+      refreshModel: true,
+    },
+  };
+
+  model() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+  }
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,1 +1,4 @@
 
+.only-when-route-not-idle {
+  color: green;
+}

--- a/tests/dummy/app/templates/docs/route-idle-helper.md
+++ b/tests/dummy/app/templates/docs/route-idle-helper.md
@@ -2,8 +2,12 @@
 
 The `route-idle` helper allows you to use `ember-app-scheduler`'s `whenRouteIdle` functionality directly in your template. Using this helper will allow you to add hidden content that is to be deferred until the route is considered idle.
 
+Note that `route-idle` will recompute when a router transition is triggered (e.g. updating the model on a route).
+
 ```hbs
 {{#if (route-idle)}}
   <span id="content-to-defer">Content to only show once the route is idle</span>
+{{else}}
+  <span id="content-to-show-while-working">Content to only show while the route is not idle</span>
 {{/if}}
 ```

--- a/tests/dummy/app/templates/route-idle-helper.hbs
+++ b/tests/dummy/app/templates/route-idle-helper.hbs
@@ -1,0 +1,9 @@
+<div>
+  {{#if (route-idle)}}
+    <span class="only-when-route-idle">When Route Idle</span>
+  {{else}}
+    <span class="only-when-route-not-idle">When Route Not Idle</span>
+  {{/if}}
+
+  <button class="refresh-button" {{on "click" this.updateRefreshQP}}>Refresh</button>
+</div>

--- a/tests/dummy/app/templates/route-idle-helper.hbs
+++ b/tests/dummy/app/templates/route-idle-helper.hbs
@@ -5,5 +5,5 @@
     <span class="only-when-route-not-idle">When Route Not Idle</span>
   {{/if}}
 
-  <button class="refresh-button" {{on "click" this.updateRefreshQP}}>Refresh</button>
+  <button class="refresh-button" type="button" {{on "click" this.updateRefreshQP}}>Refresh</button>
 </div>

--- a/tests/integration/helpers/route-idle-test.js
+++ b/tests/integration/helpers/route-idle-test.js
@@ -1,8 +1,8 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import { beginTransition, endTransition } from 'ember-app-scheduler';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
 module('Integration | Helper | route-idle', function (hooks) {
   setupRenderingTest(hooks);
@@ -58,7 +58,8 @@ module('Integration | Helper | route-idle', function (hooks) {
     await settled();
     // FIRST TRANSITION: END
 
-    // SECOND TRANSITION: START
+    // SIMULATE SECOND TRANSITION: START
+    this.owner.lookup('service:router').trigger('routeWillChange');
     beginTransition();
 
     await settled();
@@ -78,6 +79,6 @@ module('Integration | Helper | route-idle', function (hooks) {
       .exists('deferred content is rendered after second transition finishes');
 
     await settled();
-    // SECOND TRANSITION: END
+    // SIMULATE SECOND TRANSITION: END
   });
 });

--- a/tests/integration/helpers/route-idle-test.js
+++ b/tests/integration/helpers/route-idle-test.js
@@ -4,10 +4,12 @@ import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { beginTransition, endTransition } from 'ember-app-scheduler';
 
-module('Integration | Helper | route-idle', function(hooks) {
+module('Integration | Helper | route-idle', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('deferred content is visible following whenRouteIdle', async function(assert) {
+  test('deferred content is visible following whenRouteIdle', async function (assert) {
+    assert.expect(2);
+
     beginTransition();
 
     await render(hbs`
@@ -25,5 +27,57 @@ module('Integration | Helper | route-idle', function(hooks) {
     assert.dom('#i-exist').exists();
 
     await settled();
+  });
+
+  test('deferred content is hidden following subsequent transitions', async function (assert) {
+    assert.expect(4);
+
+    // FIRST TRANSITION: START
+    beginTransition();
+
+    await render(hbs`
+      {{#if (route-idle)}}
+        <span id="i-exist">Idle content</span>
+      {{/if}}
+    `);
+
+    assert
+      .dom('#i-exist')
+      .doesNotExist(
+        'deferred content is hidden while initial transition begins'
+      );
+
+    endTransition();
+
+    await settled();
+
+    assert
+      .dom('#i-exist')
+      .exists('deferred content is rendered after initial transition finishes');
+
+    await settled();
+    // FIRST TRANSITION: END
+
+    // SECOND TRANSITION: START
+    beginTransition();
+
+    await settled();
+
+    assert
+      .dom('#i-exist')
+      .doesNotExist(
+        'deferred content is hidden while second transition is entered'
+      );
+
+    endTransition();
+
+    await settled();
+
+    assert
+      .dom('#i-exist')
+      .exists('deferred content is rendered after second transition finishes');
+
+    await settled();
+    // SECOND TRANSITION: END
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     "target": "es2017",
     "allowJs": true,
     "moduleResolution": "node",


### PR DESCRIPTION
From #897:

> The route-idle helper is super useful for many use cases of when-route-idle. However, I've found that when using the helper in route templates it never recomputes. On initial entry to the route it will work properly, but if the route is re-entered later (e.g. loading a different model), it will immediately return true.
>
> This can lead to (IMHO) unexpected behavior, since I would expect the helper to recompute when the route is no longer idle.

This change proposes fixing the above issue by recomputing the `route-idle` helper on the router service's `routeWillChange` event. See attached videos for comparison of old and new behavior.

Risks:
- The Router service is only available from Ember version >= 3.6.0, so this fix will only work those versions
- This is a potentially breaking change for clients relying on the old behavior of the `route-idle` helper

BEFORE
![BEFORE](https://user-images.githubusercontent.com/6628782/99117414-83277000-25aa-11eb-87c3-31eb340254cc.gif)

AFTER
![AFTER](https://user-images.githubusercontent.com/6628782/99117431-8ae71480-25aa-11eb-9104-aeaa52d7b491.gif)

Fixes #897 
Closes #898 