### PR TITLE
Drop Node.js 10 support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: install dependencies
         run: yarn install
       - name: lint
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: install dependencies
         run: yarn install
       - name: test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The [documentation website](https://ember-app-scheduler.github.io/ember-app-sche
 
 ## Compatibility
 
-- Ember.js v3.16 or above
+* Ember.js v3.16 or above
+* Ember CLI v2.13 or above
+* Node.js v12 or above
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "cheerio": "1.0.0-rc.2"
   },
   "engines": {
-    "node": ">= 10.*"
+    "node": "12.* || 14.* || >= 16"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Follow the Node support policy this drops support for Node 10
which reached end of life on 2021-04-30.