### PR TITLE
Cache dependencies in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,34 +11,49 @@ on:
 
 jobs:
   test:
-    name: Tests
+    name: "Tests"
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - name: install dependencies
-        run: yarn install
-      - name: lint
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint
         run: |
           yarn lint:hbs
           yarn lint:js
-      - name: test
+      - name: Run Tests
+        run: yarn test
+
+  floating:
+    name: "Floating Dependencies"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --no-lockfile
+      - name: Run Tests
         run: yarn test:ember
 
   try-scenarios:
-    name: ${{ matrix.ember-try-scenario }}
-
+    name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
-
-    needs: test
+    needs: 'test'
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        ember-try-scenario:
+        try-scenario:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-lts-3.24
@@ -51,13 +66,13 @@ jobs:
           #- embroider-optimized
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - name: install dependencies
-        run: yarn install
-      - name: test
-        env:
-          EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
-        run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+          cache: yarn
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run Tests
+        run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}


### PR DESCRIPTION
PR to speed up CI times on GitHub Actions by caching dependencies.

References:
* https://github.com/actions/setup-node#caching-packages-dependencies
* https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/files/.github/workflows/ci.yml

Main changes:
* introduces "Floating Dependencies" job
* uses `actions/setup-node@v2` with `cache: yarn` option