### PR TITLE
Use RouterService for transitionTo() fix deprecation

### DIFF
--- a/tests/dummy/app/routes/aborted-paint.js
+++ b/tests/dummy/app/routes/aborted-paint.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class AbortedPaintRoute extends Route {
+  @service router;
+
   beforeModel(transition) {
     transition.abort();
-    this.transitionTo('content-paint');
+    this.router.transitionTo('content-paint');
   }
 }


### PR DESCRIPTION
Deprecation details: https://deprecations.emberjs.com/v3.x#toc_routing-transition-methods

This will fail scenarios using Ember v4 once functionality removed from Ember.js codebase