### PR TITLE
Replace use of htmlbars-inline-precompile with ember-cli-htmlbars

### DIFF
--- a/tests/dummy/app/templates/docs/testing.md
+++ b/tests/dummy/app/templates/docs/testing.md
@@ -42,7 +42,7 @@ export default class ComponentWithDeferredStuff extends Component {
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module(
   'Integration | Component | component-with-deferred-stuff',

--- a/tests/integration/deferred-render-in-component-test.js
+++ b/tests/integration/deferred-render-in-component-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, waitFor, settled } from '@ember/test-helpers';
 import {

--- a/tests/integration/helpers/route-idle-test.js
+++ b/tests/integration/helpers/route-idle-test.js
@@ -1,7 +1,7 @@
 import { render, settled } from '@ember/test-helpers';
 import { beginTransition, endTransition } from 'ember-app-scheduler';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 
 module('Integration | Helper | route-idle', function (hooks) {


### PR DESCRIPTION
Reference https://github.com/ember-cli/ember-cli-htmlbars#tagged-template-usage--migrating-from-htmlbars-inline-precompile