### PR TITLE
Update ci config to not run all try scenarios

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,11 +3,16 @@ name: CI Build
 on:
   push:
     branches:
+      - main
       - master
       - 'v*'
   pull_request: {}
   schedule:
     - cron: '0 3 * * *' # daily, at 3am
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -24,11 +29,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Lint
-        run: |
-          yarn lint:hbs
-          yarn lint:js
+        run: yarn lint
       - name: Run Tests
-        run: yarn test
+        run: yarn test:ember
 
   floating:
     name: "Floating Dependencies"
@@ -57,10 +60,10 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-lts-3.24
+          - ember-lts-3.28
           - ember-release
           - ember-beta
           - ember-canary
-          - ember-default-with-jquery
           - ember-classic
           - embroider-safe
           #- embroider-optimized

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,6 +32,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {
@@ -52,19 +60,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^1.1.0',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -17,19 +17,18 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
+    "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
     "prepublishOnly": "ember ts:precompile",
     "postpublish": "ember ts:clean",
-    "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
-    "test:ember-compatibility": "ember try:each",
     "test:prod": "ember test --environment=production",
     "prepare": "husky install"
   },


### PR DESCRIPTION
@scalvert #1164 incorrectly updated ci config and run all `test:*` scripts from package.json in `tests` job ultimately running all ember-try scenarios in sequence.

This PR updates CI config and `package.json` scripts with latest blueprint (adding 3.28 to matrix and removing `ember-default-with-jquery`)