### PR TITLE
[fix] Make route-idle helper functionality like whenRouteIdle

### DIFF
--- a/addon/scheduler.ts
+++ b/addon/scheduler.ts
@@ -55,6 +55,7 @@ export function beginTransition(): void {
         waiter.endAsync(scheduledWorkToken);
         mark('appSchedulerEnd');
         measure('appScheduler', 'appSchedulerStart', 'appSchedulerEnd');
+        scheduler.isIdle = true;
       });
     });
     scheduler.isIdle = false;
@@ -70,7 +71,6 @@ export function beginTransition(): void {
  */
 export function endTransition(): void {
   _whenRouteDidChange.resolve();
-  scheduler.isIdle = true;
   mark('appSchedulerStart');
 }
 

--- a/tests/integration/helpers/route-idle-test.js
+++ b/tests/integration/helpers/route-idle-test.js
@@ -1,4 +1,4 @@
-import { render, settled } from '@ember/test-helpers';
+import { render, settled, waitFor } from '@ember/test-helpers';
 import { beginTransition, endTransition } from 'ember-app-scheduler';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -23,6 +23,8 @@ module('Integration | Helper | route-idle', function (hooks) {
     endTransition();
 
     await settled();
+
+    await waitFor('#i-exist');
 
     assert.dom('#i-exist').exists();
 
@@ -51,6 +53,8 @@ module('Integration | Helper | route-idle', function (hooks) {
 
     await settled();
 
+    await waitFor('#i-exist');
+
     assert
       .dom('#i-exist')
       .exists('deferred content is rendered after initial transition finishes');
@@ -73,6 +77,8 @@ module('Integration | Helper | route-idle', function (hooks) {
     endTransition();
 
     await settled();
+
+    await waitFor('#i-exist');
 
     assert
       .dom('#i-exist')


### PR DESCRIPTION
The `route-idle` helper doesn't work exactly like `whenRouteIdle`, see [#route-idle-helper](https://github.com/ember-app-scheduler/ember-app-scheduler/blob/master/tests/dummy/app/templates/docs/route-idle-helper.md#route-idle-helper).

My best understanding is that the helper ignored the **requestAnimationFrames** execution result in comparison with `whenRouteIdle()`. Therefore, content rendering was executed earlier than expected in some cases.

This PR updates the setpoint for `@tracked isIdle` to `true` on after the `afterRender` lifecycle is executed as well as test updates.